### PR TITLE
Watch for magento2 flag and apply appropriate config

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -16,6 +16,7 @@ import time
 
 DIR_TO_WATCH = '/data/web/nginx'
 CUSTOM_CONFIG_DIR = '/etc/nginx/app'
+MAIN_CONFIG_DIR = '/etc/nginx/'
 
 NGINX = '/usr/sbin/nginx'
 NGINX_PID_FILE = '/var/run/nginx.pid'
@@ -100,6 +101,12 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
         if os.path.exists(CUSTOM_CONFIG_DIR):
             shutil.move(CUSTOM_CONFIG_DIR, BACKUP_CONFIG_DIR)
         completed = False
+        if os.path.isfile(DIR_TO_WATCH+"/magento1.flag"):
+            shutil.copyfile(MAIN_CONFIG_DIR+"/magento1.conf", MAIN_CONFIG_DIR+"/magento.conf");
+        elif os.path.isfile(DIR_TO_WATCH+"/magento2.flag"):
+            shutil.copyfile(MAIN_CONFIG_DIR+"/magento2.conf", MAIN_CONFIG_DIR+"/magento.conf");
+        else:
+            shutil.copyfile(MAIN_CONFIG_DIR+"/magento1.conf", MAIN_CONFIG_DIR+"/magento.conf");
         while not completed:
             try:
                 shutil.copytree(DIR_TO_WATCH, CUSTOM_CONFIG_DIR, ignore=shutil.ignore_patterns(*IGNORE_FILES))

--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -15,19 +15,25 @@ import time
 
 
 DIR_TO_WATCH = '/data/web/nginx'
-CUSTOM_CONFIG_DIR = '/etc/nginx/app'
-MAIN_CONFIG_DIR = '/etc/nginx/'
+MAIN_CONFIG_DIR = '/etc/nginx'
+CUSTOM_CONFIG_DIR = MAIN_CONFIG_DIR + '/app'
+BACKUP_CONFIG_DIR = MAIN_CONFIG_DIR + '/app_bak'
+
+MAGENTO_CONF = MAIN_CONFIG_DIR + '/magento.conf'
+MAGENTO1_CONF = MAIN_CONFIG_DIR + '/magento1.conf'
+MAGENTO2_CONF = MAIN_CONFIG_DIR + '/magento2.conf'
+MAGENTO2_FLAG = DIR_TO_WATCH + '/magento2.flag'
 
 NGINX = '/usr/sbin/nginx'
 NGINX_PID_FILE = '/var/run/nginx.pid'
 ERROR_FILE = 'nginx_error_output'
 
-BACKUP_CONFIG_DIR = CUSTOM_CONFIG_DIR + '_bak'
 IGNORE_FILES = (
     # glob patterns
     '.*',
     '*~',
     ERROR_FILE,
+    '*.flag',
 )
 SYSLOG_SOCKET = '/dev/log'
 
@@ -100,13 +106,13 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
         shutil.rmtree(BACKUP_CONFIG_DIR, ignore_errors=True)
         if os.path.exists(CUSTOM_CONFIG_DIR):
             shutil.move(CUSTOM_CONFIG_DIR, BACKUP_CONFIG_DIR)
-        completed = False
-        if os.path.isfile(DIR_TO_WATCH+"/magento1.flag"):
-            shutil.copyfile(MAIN_CONFIG_DIR+"/magento1.conf", MAIN_CONFIG_DIR+"/magento.conf");
-        elif os.path.isfile(DIR_TO_WATCH+"/magento2.flag"):
-            shutil.copyfile(MAIN_CONFIG_DIR+"/magento2.conf", MAIN_CONFIG_DIR+"/magento.conf");
+
+        if os.path.isfile(MAGENTO2_FLAG):
+            shutil.copyfile(MAGENTO2_CONF, MAGENTO_CONF)
         else:
-            shutil.copyfile(MAIN_CONFIG_DIR+"/magento1.conf", MAIN_CONFIG_DIR+"/magento.conf");
+            shutil.copyfile(MAGENTO1_CONF, MAGENTO_CONF)
+
+        completed = False
         while not completed:
             try:
                 shutil.copytree(DIR_TO_WATCH, CUSTOM_CONFIG_DIR, ignore=shutil.ignore_patterns(*IGNORE_FILES))

--- a/tests/test_nginx_config_reloader.py
+++ b/tests/test_nginx_config_reloader.py
@@ -36,12 +36,11 @@ class TestConfigReloader(unittest.TestCase):
         shutil.rmtree(self.source, ignore_errors=True)
         shutil.rmtree(self.dest, ignore_errors=True)
         shutil.rmtree(self.backup, ignore_errors=True)
-        try:
-            os.unlink(self.mag_conf)
-            os.unlink(self.mag1_conf)
-            os.unlink(self.mag2_conf)
-        except OSError:
-            pass
+        for f in [self.mag_conf, self.mag1_conf, self.mag2_conf]:
+            try:
+                os.unlink(f)
+            except OSError:
+                pass
 
     def test_that_apply_new_config_moves_files_to_dest_dir(self):
         self._write_file(self._source('myfile'), 'config contents')

--- a/tests/test_nginx_config_reloader.py
+++ b/tests/test_nginx_config_reloader.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from tempfile import mkdtemp
+from tempfile import mkdtemp, mkstemp, NamedTemporaryFile
 import unittest
 import shutil
 import signal
@@ -15,10 +15,19 @@ class TestConfigReloader(unittest.TestCase):
         self.get_pid.return_value = 42
 
         self.source = mkdtemp()
-        nginx_config_reloader.DIR_TO_WATCH = self.source
         self.dest = mkdtemp()
+        self.backup = mkdtemp()
+        _, self.mag_conf = mkstemp(text=True)
+        _, self.mag1_conf = mkstemp(text=True)
+        _, self.mag2_conf = mkstemp(text=True)
+
+        nginx_config_reloader.DIR_TO_WATCH = self.source
         nginx_config_reloader.CUSTOM_CONFIG_DIR = self.dest
-        nginx_config_reloader.BACKUP_CONFIG_DIR = mkdtemp()
+        nginx_config_reloader.BACKUP_CONFIG_DIR = self.backup
+
+        nginx_config_reloader.MAGENTO_CONF = self.mag_conf
+        nginx_config_reloader.MAGENTO1_CONF = self.mag1_conf
+        nginx_config_reloader.MAGENTO2_CONF = self.mag2_conf
 
         self.test_config = self._patch('subprocess.check_output')
         self.kill = self._patch('os.kill')
@@ -26,7 +35,10 @@ class TestConfigReloader(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.source, ignore_errors=True)
         shutil.rmtree(self.dest, ignore_errors=True)
-        shutil.rmtree(nginx_config_reloader.BACKUP_CONFIG_DIR, ignore_errors=True)
+        shutil.rmtree(self.backup, ignore_errors=True)
+        os.unlink(self.mag_conf)
+        os.unlink(self.mag1_conf)
+        os.unlink(self.mag2_conf)
 
     def test_that_apply_new_config_moves_files_to_dest_dir(self):
         self._write_file(self._source('myfile'), 'config contents')
@@ -46,6 +58,29 @@ class TestConfigReloader(unittest.TestCase):
 
         contents = self._read_file(self._dest('myfile'))
         self.assertEqual(contents, 'config contents')
+
+    def test_that_apply_new_config_defaults_to_magento1_config(self):
+        self._write_file(self.mag1_conf, 'magento1 config')
+        self._write_file(self.mag2_conf, 'magento2 config')
+
+        tm = nginx_config_reloader.NginxConfigReloader()
+        tm.apply_new_config()
+
+        contents = self._read_file(self.mag_conf)
+        self.assertEqual(contents, 'magento1 config')
+
+    def test_that_apply_new_config_enables_magento1_config_if_customer_sets_flag(self):
+        self._write_file(self.mag1_conf, 'magento1 config')
+        self._write_file(self.mag2_conf, 'magento2 config')
+
+        with NamedTemporaryFile() as f:
+            nginx_config_reloader.MAGENTO2_FLAG = f.name
+
+            tm = nginx_config_reloader.NginxConfigReloader()
+            tm.apply_new_config()
+
+        contents = self._read_file(self.mag_conf)
+        self.assertEqual(contents, 'magento2 config')
 
     def test_that_apply_new_config_keeps_files_in_source_dir(self):
         self._write_file(self._source('myfile'), 'config contents')
@@ -146,6 +181,14 @@ class TestConfigReloader(unittest.TestCase):
         tm.apply_new_config()
 
         self.assertFalse(os.path.exists(self._dest('.config.swp')))
+
+    def test_that_flags_are_not_moved_to_dest_dir(self):
+        self._write_file(self._source('whatever.flag'), '')
+
+        tm = nginx_config_reloader.NginxConfigReloader()
+        tm.apply_new_config()
+
+        self.assertFalse(os.path.exists(self._dest('whatever.flag')))
 
     def test_that_handle_event_applies_config(self):
         tm = nginx_config_reloader.NginxConfigReloader()


### PR DESCRIPTION
@JeroenvHeugten @allardhoeve 

Depends on seperate `magento1.conf` and `magento2.conf` that @JeroenvHeugten is working on.

This PR will apply `magento2.conf` if customer sets a flag. If flag is absent, defaults to `magento1.conf`.