### PR TITLE
update buildpackage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ nosetests
 VERSION=$(date "+%Y%m%d.%H%M%S")
 
 # Generate and commit changelog
-git-dch --debian-tag="%(version)s" --new-version=$VERSION --debian-branch master --release --commit
+gbp dch --debian-tag="%(version)s" --new-version=$VERSION --debian-branch master --release --commit
 
 # Tag current version
 git tag $VERSION
@@ -51,5 +51,5 @@ git push
 git push --tags
 
 # Build package
-git-buildpackage --git-pbuilder --git-dist=precise --git-arch=amd64 --git-debian-branch=master
+gbp buildpackage --git-pbuilder --git-dist=precise --git-arch=amd64 --git-debian-branch=master
 ```


### PR DESCRIPTION
git-buildpackage and git-dch are deprecated

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=783537
https://packages.qa.debian.org/g/git-buildpackage/news/20150220T194850Z.html

Because in Ubuntu 16.04:

> [e3a8666] Drop all gbp-* and git-* commands as announced in the deprecation notice from June 2013. From now on only "gbp " is supported.