### PR TITLE
do not allow includes in the config by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install -e git+https://github.com/ByteInternet/nginx_config_reloader#egg=ngi
 
 ```sh
 pip install -r requirements.txt
-nosetests
+./runtests.sh -1
 ```
 
 ## Building debian packages

--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -37,6 +37,9 @@ WATCH_IGNORE_FILES = (
 SYNC_IGNORE_FILES = WATCH_IGNORE_FILES + ('*.flag',)
 SYSLOG_SOCKET = '/dev/log'
 
+ILLEGAL_INCLUDE_REGEX = "^(?!\s*#)\s*(include|load_module)\s*(?=.*\.\.|/etc/nginx/app|/(?!etc/nginx))"
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -115,9 +118,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
             # - it is in a comment
             # - the include is a relative path but does not start with ..
             # - the include is absolute but to the MAIN_CONFIG_DIR
-            check_external_resources = "[ $(grep --no-filename -r 'include\|load_module' '{}' | " \
-                                       "grep -v '^\s*#\|include [^/\|^..]\|{}' | wc -l) -lt 1 ]" \
-                                       "".format(DIR_TO_WATCH, MAIN_CONFIG_DIR)
+            check_external_resources = "grep -r -P '{}' /data/web/nginx/*".format(ILLEGAL_INCLUDE_REGEX)
             subprocess.check_output(check_external_resources, shell=True)
 
     def apply_new_config(self):

--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -37,7 +37,8 @@ WATCH_IGNORE_FILES = (
 SYNC_IGNORE_FILES = WATCH_IGNORE_FILES + ('*.flag',)
 SYSLOG_SOCKET = '/dev/log'
 
-ILLEGAL_INCLUDE_REGEX = "^(?!\s*#)\s*(include|load_module)\s*(?=.*\.\.|/etc/nginx/app|/(?!etc/nginx))"
+# Because of bash escaping problems we define quote's in octal format \042 == ' and \047 == "
+ILLEGAL_INCLUDE_REGEX = "^(?!\s*#)\s*(include|load_module)\s*(\\042|\\047)?(?=.*\.\.|/+etc/+nginx/+app_bak|/+(?!etc/+nginx))(\\042|\\047)?"
 
 
 logger = logging.getLogger(__name__)

--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -42,12 +42,13 @@ logger = logging.getLogger(__name__)
 
 class NginxConfigReloader(pyinotify.ProcessEvent):
 
-    def my_init(self, logger=None):
+    def my_init(self, logger=None, allow_includes=False):
         """Constructor called by ProcessEvent"""
         if not logger:
             self.logger = logging
         else:
             self.logger = logger
+        self.allow_includes = allow_includes
 
     def process_IN_DELETE(self, event):
         """Triggered by inotify on removal of file or removal of dir
@@ -102,7 +103,26 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
         # Move temporary symlink to actual location, overwriting existing link or file
         os.rename(MAGENTO_CONF_NEW, MAGENTO_CONF)
 
+    @staticmethod
+    def assert_no_includes_in_config():
+        if os.path.isdir(DIR_TO_WATCH):
+            check_external_resources = [
+                "/bin/grep", "-q", "'include\|load_module", DIR_TO_WATCH
+            ]
+            subprocess.check_output(check_external_resources)
+
     def apply_new_config(self):
+        if not self.allow_includes:
+            try:
+                self.assert_no_includes_in_config()
+            except subprocess.CalledProcessError:
+                self.logger.error("Config is not allowed to load external resources")
+                self.write_error_file(
+                    "You are not allowed to use include or load_module in the nginx config. "
+                    "See the NGINX dos and don'ts in this article: "
+                    "https://support.hypernode.com/knowledgebase/how-to-use-nginx/"
+                )
+                return False
         try:
             self.install_magento_config()
         except OSError:
@@ -172,7 +192,7 @@ class ListenTargetTerminated(BaseException):
     pass
 
 
-def wait_loop(logger=None):
+def wait_loop(logger=None, allow_includes=False):
     """Main event loop
 
     There is an outer loop that checks the availability of the directory to watch.
@@ -182,7 +202,7 @@ def wait_loop(logger=None):
     inner loop and we're back here in the outer loop.
     """
     wm = pyinotify.WatchManager()
-    handler = NginxConfigReloader(logger=logger)
+    handler = NginxConfigReloader(logger=logger, allow_includes=allow_includes)
     notifier = pyinotify.Notifier(wm, default_proc_fun=handler)
 
     while True:
@@ -204,11 +224,20 @@ def wait_loop(logger=None):
             logger.warning("Configuration dir lost, waiting for it to reappear")
 
 
-def main():
+def parse_nginx_config_reloader_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument('--daemon', '-d', action='store_true', help='Fork to background and run as daemon')
     parser.add_argument('--monitor', '-m', action='store_true', help='Monitor files on foreground with output')
-    args = parser.parse_args()
+    parser.add_argument(
+        '--allow-includes', action='store_true',
+        help='Allow the config to contain includes (default False)'
+    )
+    return parser.parse_args()
+
+
+def main():
+
+    args = parse_nginx_config_reloader_arguments()
 
     if args.monitor:
         handler = logging.StreamHandler()
@@ -216,7 +245,7 @@ def main():
         logger.setLevel(logging.DEBUG)
         logger.addHandler(handler)
 
-        wait_loop(logger=logger)
+        wait_loop(logger=logger, allow_includes=args.allow_includes)
 
     if args.daemon:
         handler = logging.handlers.SysLogHandler(address=SYSLOG_SOCKET)
@@ -226,7 +255,7 @@ def main():
 
         pidfile = daemon.pidlockfile.PIDLockFile('/var/run/%s.pid' % os.path.basename(sys.argv[0]))
         with daemon.DaemonContext(pidfile=pidfile, files_preserve=[handler.socket.fileno()]):
-            wait_loop(logger=logger)
+            wait_loop(logger=logger, allow_includes=args.allow_includes)
 
     else:
         tm = NginxConfigReloader()

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export PYTHONPATH=.
+
+if [ "$1" == "-1" ]; then
+    nosetests;
+else
+    watch -n 1 -- nosetests;
+fi

--- a/tests/test_assert_no_includes_in_config.py
+++ b/tests/test_assert_no_includes_in_config.py
@@ -22,19 +22,17 @@ class TestAssertNoIncludesInConfig(TestCase):
 
         self.assertFalse(self.check_output.called)
 
-    def test_assert_no_includes_in_config_checks_user_nginx_dir_for_forbidden_includes(self):
-        NginxConfigReloader.assert_no_includes_in_config()
-
-        expected_command = "grep -r -P '^(?!\\s*#)\\s*(include|load_module)" \
-                           "\\s*(?=.*\\.\\.|/etc/nginx/app|/(?!etc/nginx))' /data/web/nginx/*"
-        self.check_output.assert_called_once_with(expected_command, shell=True)
-
     def test_include_prevention_legal_includes(self):
         no_matches = [
             "include /etc/nginx/fastcgi_params",
             "include \"/etc/nginx/php-handler.conf\";",
             "include '/etc/nginx/php-handler.conf';",
             "include /etc/nginx/fastcgi_params",
+            "include handler.conf",
+            "include relative_file.conf",
+            "include /etc/nginx/app/server.*;",
+            "include /etc/nginx//fastcgi_params",
+            "include /etc//nginx/fastcgi_params",
         ]
 
         for line in no_matches:
@@ -46,6 +44,16 @@ class TestAssertNoIncludesInConfig(TestCase):
         matches = [
             "include /data/web/nginx/someexample.allow;",
             "include /etc/nginx/../../data/web/banaan.config",
+            'include "/etc/nginx/../../data/web/banaan.config"',
+            "include '/etc/nginx/../data/web/banaan.config'",
+            "include /data/web/banaan.config",
+            "include somedir/../../../../danger",
+            "include '/data/web/banaan.config'",
+            'include "/data/web/banaan.config"',
+            "include /etc/nginx/app_bak/server.*;",
+            'include "/data//web/banaan.config"',
+            'include "//data/web/banaan.config"',
+            'include "/data/web//banaan.config"'
         ]
 
         for line in matches:

--- a/tests/test_assert_no_includes_in_config.py
+++ b/tests/test_assert_no_includes_in_config.py
@@ -1,0 +1,28 @@
+from nginx_config_reloader import NginxConfigReloader
+from tests.testcase import TestCase
+
+
+class TestAssertNoIncludesInConfig(TestCase):
+    def setUp(self):
+        self.isdir = self.set_up_patch(
+            'nginx_config_reloader.os.path.isdir'
+        )
+        self.isdir.return_value = True
+        self.check_output = self.set_up_patch(
+            'nginx_config_reloader.subprocess.check_output'
+        )
+
+    def test_assert_no_includes_in_config_does_not_check_config_if_no_dir_to_watch(self):
+        self.isdir.return_value = False
+
+        NginxConfigReloader.assert_no_includes_in_config()
+
+        self.assertFalse(self.check_output.called)
+
+    def test_assert_no_includes_in_config_checks_user_nginx_dir_for_forbidden_includes(self):
+        NginxConfigReloader.assert_no_includes_in_config()
+
+        expected_command = "[ $(grep --no-filename -r 'include\|load_module' '/data/web/nginx' | " \
+                           "grep -v '^\s*#\|include [^/\|^..]\|/etc/nginx' | wc -l) -lt 1 ]"
+        self.check_output.assert_called_once_with(expected_command, shell=True)
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,62 @@
+from mock import Mock
+
+from nginx_config_reloader import logger, main
+from tests.testcase import TestCase
+
+
+class TestMain(TestCase):
+    def setUp(self):
+        self.args = Mock(
+            daemon=False,
+            monitor=True,
+            allow_includes=False
+
+        )
+        self.parse_nginx_config_reloader_arguments = self.set_up_patch(
+            'nginx_config_reloader.parse_nginx_config_reloader_arguments',
+        )
+        self.parse_nginx_config_reloader_arguments.return_value = self.args
+        self.daemoncontext = self.set_up_context_manager_patch(
+            'nginx_config_reloader.daemon.DaemonContext'
+        )
+        self.wait_loop = self.set_up_context_manager_patch(
+            'nginx_config_reloader.wait_loop'
+        )
+        self.reloader = self.set_up_context_manager_patch(
+            'nginx_config_reloader.NginxConfigReloader'
+        )
+
+    def test_main_parses_arguments(self):
+        main()
+
+        self.parse_nginx_config_reloader_arguments.assert_called_once_with()
+
+    def test_main_runs_the_reloader_in_the_foreground_if_monitor_is_specified(self):
+        main()
+
+        self.assertFalse(self.daemoncontext.called)
+        self.wait_loop.assert_called_once_with(
+            logger=logger, allow_includes=self.args.allow_includes
+        )
+
+    def test_main_runs_the_reloader_in_the_background_if_daemon_is_specified(self):
+        self.args.daemon = True
+        self.args.monitor = False
+        self.parse_nginx_config_reloader_arguments.return_value = self.args
+
+        main()
+
+        self.assertTrue(self.daemoncontext.called)
+        self.wait_loop.assert_called_once_with(
+            logger=logger, allow_includes=self.args.allow_includes
+        )
+
+    def test_main_runs_the_reloader_once_if_no_monitor_or_daemon_is_specified(self):
+        self.args.daemon = False
+        self.args.monitor = False
+        self.parse_nginx_config_reloader_arguments.return_value = self.args
+
+        main()
+
+        self.reloader.assert_called_once_with()
+        self.reloader.return_value.apply_new_config.assert_called_once_with()

--- a/tests/test_parse_nginx_config_reloader_arguments.py
+++ b/tests/test_parse_nginx_config_reloader_arguments.py
@@ -1,0 +1,37 @@
+from mock import call
+
+from nginx_config_reloader import parse_nginx_config_reloader_arguments
+from tests.testcase import TestCase
+
+
+class TestParseNginxConfigReloaderArguments(TestCase):
+    def setUp(self):
+        self.parser = self.set_up_patch(
+            'nginx_config_reloader.argparse.ArgumentParser'
+        )
+
+    def test_parse_nginx_config_reloader_arguments_instantiates_argparser(self):
+        parse_nginx_config_reloader_arguments()
+
+        self.parser.assert_called_once_with()
+
+    def test_parse_nginx_config_reloader_arguments_adds_options(self):
+        parse_nginx_config_reloader_arguments()
+
+        expected_calls = [
+            call("--daemon", '-d', action='store_true',
+                 help='Fork to background and run as daemon'),
+            call('--monitor', '-m', action='store_true',
+                 help='Monitor files on foreground with output'),
+            call('--allow-includes', action='store_true',
+                 help='Allow the config to contain includes (default False)')
+        ]
+        self.assertEqual(
+            self.parser.return_value.add_argument.mock_calls, expected_calls
+        )
+
+    def test_parse_nginx_config_reloader_arguments_returns_parsed_arguments(self):
+        ret = parse_nginx_config_reloader_arguments()
+
+        self.assertEqual(ret, self.parser.return_value.parse_args.return_value)
+

--- a/tests/test_parse_nginx_config_reloader_arguments.py
+++ b/tests/test_parse_nginx_config_reloader_arguments.py
@@ -24,7 +24,8 @@ class TestParseNginxConfigReloaderArguments(TestCase):
             call('--monitor', '-m', action='store_true',
                  help='Monitor files on foreground with output'),
             call('--allow-includes', action='store_true',
-                 help='Allow the config to contain includes (default False)')
+                 help='Allow the config to contain includes outside of'
+                      ' the system nginx config directory (default False)')
         ]
         self.assertEqual(
             self.parser.return_value.add_argument.mock_calls, expected_calls

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -1,0 +1,15 @@
+import unittest
+from mock import patch, Mock
+
+
+class TestCase(unittest.TestCase):
+    def set_up_patch(self, patch_target, mock_target=None, **kwargs):
+        patcher = patch(patch_target, mock_target or Mock(**kwargs))
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
+    def set_up_context_manager_patch(self, topatch, themock=None, **kwargs):
+        patcher = self.set_up_patch(topatch, themock=themock, **kwargs)
+        patcher.return_value.__exit__ = lambda a, b, c, d: None
+        patcher.return_value.__enter__ = lambda x: None
+        return patcher


### PR DESCRIPTION
reject configs with `include` or `load_module` so the state of the config can not change without going through the reloader.