### PR TITLE
put run once mode back in

### DIFF
--- a/debian/nginx-config-reloader.service
+++ b/debian/nginx-config-reloader.service
@@ -2,7 +2,7 @@
 Description=Daemon that detects, checks and installs user provided nginx configuration files
 
 [Service]
-ExecStart=/usr/bin/nginx_config_reloader
+ExecStart=/usr/bin/nginx_config_reloader --monitor
 StandardOutput=null
 StandardError=journal
 RestartSec=10

--- a/tests/test_get_logger.py
+++ b/tests/test_get_logger.py
@@ -1,0 +1,46 @@
+from logging import DEBUG
+
+from nginx_config_reloader import get_logger
+from tests.testcase import TestCase
+
+
+class TestGetLogger(TestCase):
+    def setUp(self):
+        self.logging = self.set_up_patch(
+            'nginx_config_reloader.logging'
+        )
+        self.handler = self.logging.StreamHandler.return_value
+        self.logger = self.set_up_patch(
+            'nginx_config_reloader.logger'
+        )
+
+    def test_get_logger_instantiates_streamhandler(self):
+        get_logger()
+
+        self.logging.StreamHandler.assert_called_once_with()
+
+    def test_get_logger_sets_custom_formatter(self):
+        get_logger()
+
+        self.handler.setFormatter.assert_called_once_with(
+            self.logging.Formatter.return_value
+        )
+
+    def test_get_logger_sets_default_logging_level_to_debug(self):
+        get_logger()
+
+        self.logger.setLevel.assert_called_once_with(
+            self.logging.DEBUG
+        )
+
+    def test_get_logger_adds_custom_logging_handler(self):
+        get_logger()
+
+        self.logger.addHandler.assert_called_once_with(
+            self.handler
+        )
+
+    def test_get_logger_returns_logger(self):
+        ret = get_logger()
+
+        self.assertEqual(self.logger, ret)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,18 @@
 from mock import Mock
 
-from nginx_config_reloader import logger, main
+from nginx_config_reloader import main
 from tests.testcase import TestCase
 
 
 class TestMain(TestCase):
     def setUp(self):
+        self.parse_nginx_config_reloader_arguments = self.set_up_patch(
+            'nginx_config_reloader.parse_nginx_config_reloader_arguments',
+            return_value=Mock(monitor=False, allow_includes=False)
+        )
+        self.get_logger = self.set_up_context_manager_patch(
+            'nginx_config_reloader.get_logger'
+        )
         self.wait_loop = self.set_up_context_manager_patch(
             'nginx_config_reloader.wait_loop'
         )
@@ -13,6 +20,77 @@ class TestMain(TestCase):
             'nginx_config_reloader.NginxConfigReloader'
         )
 
-    def test_main_runs_the_reloader_in_the_foreground_if_monitor_is_specified(self):
+    def test_main_gets_logger(self):
         main()
-        self.wait_loop.assert_called_once_with(logger=logger)
+
+        self.get_logger.assert_called_once_with()
+
+    def test_main_parses_nginx_config_reloader_arguments(self):
+        main()
+
+        self.parse_nginx_config_reloader_arguments.assert_called_once_with()
+
+    def test_main_reloads_config_once_if_monitor_mode_not_specified(self):
+        main()
+
+        self.reloader.assert_called_once_with(
+            logger=self.get_logger.return_value,
+            allow_includes=False
+        )
+        self.reloader.return_value.apply_new_config()
+
+    def test_main_reloads_config_once_if_monitor_mode_not_specified_and_includes_allowed(self):
+        self.parse_nginx_config_reloader_arguments.return_value.allow_includes = True
+
+        main()
+
+        self.reloader.assert_called_once_with(
+            logger=self.get_logger.return_value,
+            allow_includes=True
+        )
+        self.reloader.return_value.apply_new_config()
+
+    def test_main_does_not_watch_the_config_dir_if_monitor_mode_not_specified(self):
+        main()
+
+        self.assertFalse(self.wait_loop.called)
+
+    def test_main_returns_zero_if_no_errors_after_reloading_once(self):
+        ret = main()
+
+        self.assertEqual(0, ret)
+
+    def test_main_watches_the_config_dir_if_monitor_specified(self):
+        self.parse_nginx_config_reloader_arguments.return_value.monitor = True
+
+        main()
+
+        self.wait_loop.assert_called_once_with(
+            logger=self.get_logger.return_value,
+            allow_includes=False
+        )
+
+    def test_main_watches_the_config_dir_if_monitor_mode_is_specified_and_includes_allowed(self):
+        self.parse_nginx_config_reloader_arguments.return_value.allow_includes = True
+        self.parse_nginx_config_reloader_arguments.return_value.monitor = True
+
+        main()
+
+        self.wait_loop.assert_called_once_with(
+            logger=self.get_logger.return_value,
+            allow_includes=True
+        )
+
+    def test_main_does_not_reload_the_config_once_if_monitor_mode_is_specified(self):
+        self.parse_nginx_config_reloader_arguments.return_value.monitor = True
+
+        main()
+
+        self.assertFalse(self.reloader.called)
+
+    def test_main_returns_nonzero_if_monitor_mode_and_loop_returns(self):
+        self.parse_nginx_config_reloader_arguments.return_value.monitor = True
+
+        ret = main()
+
+        self.assertEqual(1, ret)

--- a/tests/test_parse_nginx_config_reloader_arguments.py
+++ b/tests/test_parse_nginx_config_reloader_arguments.py
@@ -1,0 +1,35 @@
+from mock import call
+
+from nginx_config_reloader import parse_nginx_config_reloader_arguments
+from tests.testcase import TestCase
+
+
+class TestParseNginxConfigReloaderArguments(TestCase):
+    def setUp(self):
+        self.parser = self.set_up_patch(
+            'nginx_config_reloader.argparse.ArgumentParser'
+        )
+
+    def test_parse_nginx_config_reloader_arguments_instantiates_argparser(self):
+        parse_nginx_config_reloader_arguments()
+
+        self.parser.assert_called_once_with()
+
+    def test_parse_nginx_config_reloader_arguments_adds_options(self):
+        parse_nginx_config_reloader_arguments()
+
+        expected_calls = [
+            call('--monitor', '-m', action='store_true',
+                 help='Monitor files on foreground with output'),
+            call('--allow-includes', action='store_true',
+                 help='Allow the config to contain includes outside of'
+                      ' the system nginx config directory (default False)')
+        ]
+        self.assertEqual(
+            self.parser.return_value.add_argument.mock_calls, expected_calls
+        )
+
+    def test_parse_nginx_config_reloader_arguments_returns_parsed_arguments(self):
+        ret = parse_nginx_config_reloader_arguments()
+
+        self.assertEqual(ret, self.parser.return_value.parse_args.return_value)


### PR DESCRIPTION
on xenial we still should be able to run the nginx config reloader once instead of always looping without any options.

PR on https://github.com/ByteInternet/nginx_config_reloader/pull/8