### PR TITLE
always restart nginx_config_reloader

### DIFF
--- a/debian/nginx-config-reloader.service
+++ b/debian/nginx-config-reloader.service
@@ -6,7 +6,7 @@ ExecStart=/usr/bin/nginx_config_reloader
 StandardOutput=null
 StandardError=journal
 RestartSec=10
-Restart=on-failure
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
not just on-failure, we also want to restart it if it didn't exit cleanly

> If set to always, the service will be restarted regardless of whether
> it exited cleanly or not, got terminated abnormally by a signal, or
> hit a timeout.

https://www.freedesktop.org/software/systemd/man/systemd.service.html