### PR TITLE
when running onetime reloader, pass allow-includes

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -283,7 +283,7 @@ def main():
             wait_loop(logger=logger, allow_includes=args.allow_includes)
 
     else:
-        tm = NginxConfigReloader()
+        tm = NginxConfigReloader(allow_includes=args.allow_includes)
         tm.apply_new_config()
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -58,5 +58,5 @@ class TestMain(TestCase):
 
         main()
 
-        self.reloader.assert_called_once_with()
+        self.reloader.assert_called_once_with(allow_includes=self.args.allow_includes)
         self.reloader.return_value.apply_new_config.assert_called_once_with()


### PR DESCRIPTION
currently allowing includes for a one-time run is not allowed/possible