### PR TITLE
Add arguments to make usage in non-hypernode platforms possible

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -20,7 +20,6 @@ BACKUP_CONFIG_DIR = MAIN_CONFIG_DIR + '/app_bak'
 MAGENTO_CONF = MAIN_CONFIG_DIR + '/magento.conf'
 MAGENTO1_CONF = MAIN_CONFIG_DIR + '/magento1.conf'
 MAGENTO2_CONF = MAIN_CONFIG_DIR + '/magento2.conf'
-MAGENTO2_FLAG = DIR_TO_WATCH + '/magento2.flag'
 
 INSTALL_MAGENTO_CONFIG = True
 INSTALL_CUSTOM_CONFIG = True
@@ -70,12 +69,27 @@ logger = logging.getLogger(__name__)
 
 class NginxConfigReloader(pyinotify.ProcessEvent):
 
-    def my_init(self, logger=None):
-        """Constructor called by ProcessEvent"""
+    def my_init(self, logger=None, no_magento_config=False, no_custom_config=False, dir_to_watch=DIR_TO_WATCH, magento2_flag=None):
+        """Constructor called by ProcessEvent
+
+        :param obj logger: The logger object
+        :param bool no_magento_config: True if we should not install Magento configuration
+        :param bool no_custom_config: True if we should not copy custom configuration
+        :param str dir_to_watch: The directory to watch
+        :param str magento2_flag: Magento 2 flag location
+        """
         if not logger:
             self.logger = logging
         else:
             self.logger = logger
+        self.no_magento_config = no_magento_config
+        self.no_custom_config = no_custom_config
+        self.dir_to_watch = dir_to_watch
+        if not magento2_flag:
+            self.magento2_flag = dir_to_watch + '/magento2.flag'
+        else:
+            self.magento2_flag = magento2_flag
+        self.logger.info(self.dir_to_watch)
 
     def process_IN_DELETE(self, event):
         """Triggered by inotify on removal of file or removal of dir
@@ -122,7 +136,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
             pass
 
         # Symlink new config to temporary filename
-        if os.path.isfile(MAGENTO2_FLAG):
+        if os.path.isfile(self.magento2_flag):
             os.symlink(MAGENTO2_CONF, MAGENTO_CONF_NEW)
         else:
             os.symlink(MAGENTO1_CONF, MAGENTO_CONF_NEW)
@@ -138,12 +152,12 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
                         True    if forbidden config directives are present
                         False   if check couldn't find any forbidden config flags
         """
-        if os.path.isdir(DIR_TO_WATCH):
+        if os.path.isdir(self.dir_to_watch):
             for rules in FORBIDDEN_CONFIG_REGEX:
                 try:
                     check_external_resources = \
                         "[ $(grep -r -P '{}' '{}' | wc -l) -lt 1 ]".format(
-                            rules[0], DIR_TO_WATCH
+                            rules[0], self.dir_to_watch
                         )
                     subprocess.check_output(check_external_resources, shell=True)
                 except subprocess.CalledProcessError:
@@ -157,14 +171,14 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
         if self.check_no_forbidden_config_directives_are_present():
             return False
 
-        if INSTALL_MAGENTO_CONFIG:
+        if not self.no_magento_config:
             try:
                 self.install_magento_config()
             except OSError:
                 self.logger.error("Installation of magento config failed")
                 return False
 
-        if INSTALL_CUSTOM_CONFIG:
+        if not self.no_custom_config:
             try:
                 self.install_new_custom_config_dir()
             except OSError:
@@ -175,13 +189,13 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
             subprocess.check_output([NGINX, '-t'], stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             self.logger.info("Config check failed")
-            if INSTALL_CUSTOM_CONFIG:
+            if not self.no_custom_config:
                 self.restore_old_custom_config_dir()
             self.write_error_file(e.output)
             return False
         else:
             try:
-                os.unlink(os.path.join(DIR_TO_WATCH, ERROR_FILE))
+                os.unlink(os.path.join(self.dir_to_watch, ERROR_FILE))
             except OSError:
                 pass
 
@@ -195,7 +209,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
         completed = False
         while not completed:
             try:
-                shutil.copytree(DIR_TO_WATCH, CUSTOM_CONFIG_DIR, ignore=shutil.ignore_patterns(*SYNC_IGNORE_FILES))
+                shutil.copytree(self.dir_to_watch, CUSTOM_CONFIG_DIR, ignore=shutil.ignore_patterns(*SYNC_IGNORE_FILES))
                 completed = True
             except shutil.Error:
                 pass  # retry
@@ -221,7 +235,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
             return None
 
     def write_error_file(self, error):
-        with open(os.path.join(DIR_TO_WATCH, ERROR_FILE), 'w') as f:
+        with open(os.path.join(self.dir_to_watch, ERROR_FILE), 'w') as f:
             f.write(error)
 
 
@@ -229,7 +243,7 @@ class ListenTargetTerminated(BaseException):
     pass
 
 
-def wait_loop(logger=None):
+def wait_loop(logger=None, no_magento_config=False, no_custom_config=False, dir_to_watch=DIR_TO_WATCH):
     """Main event loop
 
     There is an outer loop that checks the availability of the directory to watch.
@@ -237,23 +251,29 @@ def wait_loop(logger=None):
     configuration changes in an inner event loop. When the monitored directory is
     renamed or removed, the inotify-handler raises an exception to break out of the
     inner loop and we're back here in the outer loop.
+
+    :param obj logger: The logger object
+    :param bool no_magento_config: True if we should not install Magento configuration
+    :param bool no_custom_config: True if we should not copy custom configuration
+    :param str dir_to_watch: The directory to watch
+    :return None:
     """
     wm = pyinotify.WatchManager()
-    handler = NginxConfigReloader(logger=logger)
+    handler = NginxConfigReloader(logger=logger, no_magento_config=no_magento_config, no_custom_config=no_custom_config, dir_to_watch=dir_to_watch)
     notifier = pyinotify.Notifier(wm, default_proc_fun=handler)
 
     while True:
-        while not os.path.exists(DIR_TO_WATCH):
-            logger.warning("Configuration dir %s not found, waiting..." % DIR_TO_WATCH)
+        while not os.path.exists(dir_to_watch):
+            logger.warning("Configuration dir %s not found, waiting..." % dir_to_watch)
             time.sleep(5)
 
-        wm.add_watch(DIR_TO_WATCH, pyinotify.ALL_EVENTS)
+        wm.add_watch(dir_to_watch, pyinotify.ALL_EVENTS)
 
         # Install initial configuration
         handler.apply_new_config()
 
         try:
-            logger.info("Listening for changes to %s" % DIR_TO_WATCH)
+            logger.info("Listening for changes to %s" % dir_to_watch)
             notifier.loop()
         except pyinotify.NotifierError as err:
             logger.critical(err)
@@ -264,9 +284,9 @@ def wait_loop(logger=None):
 def parse_nginx_config_reloader_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument('--monitor', '-m', action='store_true', help='Monitor files on foreground with output')
-    parser.add_argument('--nomagentoconfig', action='store_true', help='Disable Magento configuration')
-    parser.add_argument('--nocustomconfig', action='store_true', help='Disable copying custom configuration')
-    parser.add_argument('--watchdir', '-w', help='Set directory to watch')
+    parser.add_argument('--nomagentoconfig', action='store_true', help='Disable Magento configuration', default=False)
+    parser.add_argument('--nocustomconfig', action='store_true', help='Disable copying custom configuration', default=False)
+    parser.add_argument('--watchdir', '-w', help='Set directory to watch', default=DIR_TO_WATCH)
     return parser.parse_args()
 
 
@@ -282,27 +302,23 @@ def main():
     args = parse_nginx_config_reloader_arguments()
     log = get_logger()
 
-    if args.nomagentoconfig:
-        global INSTALL_MAGENTO_CONFIG
-        INSTALL_MAGENTO_CONFIG = False
-
-    if args.nocustomconfig:
-        global INSTALL_CUSTOM_CONFIG
-        INSTALL_CUSTOM_CONFIG = False
-
-    if args.watchdir:
-        global DIR_TO_WATCH
-        DIR_TO_WATCH = args.watchdir
-
     if args.monitor:
         # Track changed files in the nginx config dir and reload on change
-        wait_loop(logger=log)
+        wait_loop(
+            logger=log,
+            no_magento_config=args.nomagentoconfig,
+            no_custom_config=args.nocustomconfig,
+            dir_to_watch=args.watchdir
+        )
         # should never return
         return 1
     else:
         # Reload the config once
         NginxConfigReloader(
             logger=log,
+            no_magento_config=args.nomagentoconfig,
+            no_custom_config=args.nocustomconfig,
+            dir_to_watch=args.watchdir
         ).apply_new_config()
         return 0
 

--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -269,6 +269,7 @@ def parse_nginx_config_reloader_arguments():
     parser.add_argument('--monitor', '-m', action='store_true', help='Monitor files on foreground with output')
     parser.add_argument('--nomagentoconfig', action='store_true', help='Disable Magento configuration')
     parser.add_argument('--nocustomconfig', action='store_true', help='Disable copying custom configuration')
+    parser.add_argument('--watchdir', '-w', help='Set directory to watch')
     return parser.parse_args()
 
 
@@ -283,6 +284,10 @@ def main():
     if args.nocustomconfig:
         global INSTALL_CUSTOM_CONFIG
         INSTALL_CUSTOM_CONFIG = False
+
+    if args.watchdir:
+        global DIR_TO_WATCH
+        DIR_TO_WATCH = args.watchdir
 
     if args.monitor:
         handler = logging.StreamHandler()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,14 +1,18 @@
 from mock import Mock
 
+import shutil
+from tempfile import mkdtemp
 from nginx_config_reloader import main
 from tests.testcase import TestCase
 
 
 class TestMain(TestCase):
     def setUp(self):
+        self.source = mkdtemp()
         self.parse_nginx_config_reloader_arguments = self.set_up_patch(
             'nginx_config_reloader.parse_nginx_config_reloader_arguments',
-            return_value=Mock(monitor=False, allow_includes=False)
+            return_value=Mock(monitor=False, allow_includes=False,
+                nomagentoconfig=False, nocustomconfig=False, watchdir=self.source)
         )
         self.get_logger = self.set_up_context_manager_patch(
             'nginx_config_reloader.get_logger'
@@ -19,6 +23,9 @@ class TestMain(TestCase):
         self.reloader = self.set_up_context_manager_patch(
             'nginx_config_reloader.NginxConfigReloader'
         )
+
+    def tearDown(self):
+        shutil.rmtree(self.source, ignore_errors=True)
 
     def test_main_gets_logger(self):
         main()
@@ -35,6 +42,9 @@ class TestMain(TestCase):
 
         self.reloader.assert_called_once_with(
             logger=self.get_logger.return_value,
+            no_magento_config=self.parse_nginx_config_reloader_arguments.return_value.nomagentoconfig,
+            no_custom_config=self.parse_nginx_config_reloader_arguments.return_value.nocustomconfig,
+            dir_to_watch=self.parse_nginx_config_reloader_arguments.return_value.watchdir
         )
         self.reloader.return_value.apply_new_config()
 
@@ -53,7 +63,12 @@ class TestMain(TestCase):
 
         main()
 
-        self.wait_loop.assert_called_once_with(logger=self.get_logger.return_value)
+        self.wait_loop.assert_called_once_with(
+            logger=self.get_logger.return_value,
+            no_magento_config=self.parse_nginx_config_reloader_arguments.return_value.nomagentoconfig,
+            no_custom_config=self.parse_nginx_config_reloader_arguments.return_value.nocustomconfig,
+            dir_to_watch=self.parse_nginx_config_reloader_arguments.return_value.watchdir
+        )
 
     def test_main_watches_the_config_dir_if_monitor_mode_is_specified_and_includes_allowed(self):
         self.parse_nginx_config_reloader_arguments.return_value.allow_includes = True
@@ -61,7 +76,12 @@ class TestMain(TestCase):
 
         main()
 
-        self.wait_loop.assert_called_once_with(logger=self.get_logger.return_value)
+        self.wait_loop.assert_called_once_with(
+            logger=self.get_logger.return_value,
+            no_magento_config=self.parse_nginx_config_reloader_arguments.return_value.nomagentoconfig,
+            no_custom_config=self.parse_nginx_config_reloader_arguments.return_value.nocustomconfig,
+            dir_to_watch=self.parse_nginx_config_reloader_arguments.return_value.watchdir
+        )
 
     def test_main_does_not_reload_the_config_once_if_monitor_mode_is_specified(self):
         self.parse_nginx_config_reloader_arguments.return_value.monitor = True

--- a/tests/test_nginx_config_reloader.py
+++ b/tests/test_nginx_config_reloader.py
@@ -240,6 +240,22 @@ class TestConfigReloader(TestCase):
         self.assertEqual(len(self.kill.mock_calls), 0)
         self.assertFalse(result)
 
+    def test_that_apply_new_config_does_install_magento_config_by_default(self):
+        self.set_up_patch('nginx_config_reloader.NginxConfigReloader.install_magento_config')
+
+        tm = self._get_nginx_config_reloader_instance()
+        tm.apply_new_config()
+
+        self.assertTrue(tm.install_magento_config.called)
+
+    def test_that_apply_new_config_does_install_custom_config_dir_by_default(self):
+        self.set_up_patch('nginx_config_reloader.NginxConfigReloader.install_new_custom_config_dir')
+
+        tm = self._get_nginx_config_reloader_instance()
+        tm.apply_new_config()
+
+        self.assertTrue(tm.install_new_custom_config_dir.called)
+
     def test_that_apply_new_config_does_not_install_magento_config_if_specified(self):
         self.set_up_patch('nginx_config_reloader.NginxConfigReloader.install_magento_config')
 

--- a/tests/test_nginx_config_reloader.py
+++ b/tests/test_nginx_config_reloader.py
@@ -240,6 +240,22 @@ class TestConfigReloader(TestCase):
         self.assertEqual(len(self.kill.mock_calls), 0)
         self.assertFalse(result)
 
+    def test_that_apply_new_config_does_not_install_magento_config_if_specified(self):
+        self.set_up_patch('nginx_config_reloader.NginxConfigReloader.install_magento_config')
+
+        tm = self._get_nginx_config_reloader_instance(no_magento_config=True)
+        tm.apply_new_config()
+
+        self.assertFalse(tm.install_magento_config.called)
+
+    def test_that_apply_new_config_does_not_install_custom_config_dir_if_specified(self):
+        self.set_up_patch('nginx_config_reloader.NginxConfigReloader.install_new_custom_config_dir')
+
+        tm = self._get_nginx_config_reloader_instance(no_custom_config=True)
+        tm.apply_new_config()
+
+        self.assertFalse(tm.install_new_custom_config_dir.called)
+
     def test_that_error_file_is_not_moved_to_dest_dir(self):
         self._write_file(self._source(nginx_config_reloader.ERROR_FILE), 'some error')
 
@@ -287,8 +303,13 @@ class TestConfigReloader(TestCase):
 
         self.assertEqual(len(self.kill.mock_calls), 0)
 
-    def _get_nginx_config_reloader_instance(self, magento2_flag=None):
-        return nginx_config_reloader.NginxConfigReloader(dir_to_watch=self.source, magento2_flag=magento2_flag)
+    def _get_nginx_config_reloader_instance(self, no_magento_config=False, no_custom_config=False, magento2_flag=None):
+        return nginx_config_reloader.NginxConfigReloader(
+            no_magento_config=no_magento_config,
+            no_custom_config=no_custom_config,
+            dir_to_watch=self.source,
+            magento2_flag=magento2_flag
+        )
 
     def _write_file(self, name, contents):
         with open(name, 'w') as f:

--- a/tests/test_parse_nginx_config_reloader_arguments.py
+++ b/tests/test_parse_nginx_config_reloader_arguments.py
@@ -1,5 +1,6 @@
 from mock import call
 
+import nginx_config_reloader
 from nginx_config_reloader import parse_nginx_config_reloader_arguments
 from tests.testcase import TestCase
 
@@ -21,6 +22,12 @@ class TestParseNginxConfigReloaderArguments(TestCase):
         expected_calls = [
             call('--monitor', '-m', action='store_true',
                  help='Monitor files on foreground with output'),
+            call('--nomagentoconfig', action='store_true',
+                 help='Disable Magento configuration', default=False),
+            call('--nocustomconfig', action='store_true',
+                 help='Disable copying custom configuration', default=False),
+            call('--watchdir', '-w',
+                help='Set directory to watch', default=nginx_config_reloader.DIR_TO_WATCH)
         ]
         self.assertEqual(
             self.parser.return_value.add_argument.mock_calls, expected_calls


### PR DESCRIPTION
I added 3 arguments:
- `--nomagentoconfig` Disables Magento specific configuration placement
- `--nocustomconfig` Disables custom configuration copying from watch dir to /etc/nginx/app
- `--watchdir` Specify directory to watch for changes

This allows me to edit my user nginx config files and reload nginx on change in my own local environment. I don't intend to use this for production, just for my local environment.

Please let me know if you have suggestions and/or improvements!