### PR TITLE
Disallow using init_by_lua* directives

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -61,6 +61,7 @@ FORBIDDEN_CONFIG_REGEX = \
          "or in the main nginx config directory. "
          "See the NGINX dos and don'ts in this article: "
          "https://support.hypernode.com/knowledgebase/how-to-use-nginx/\n"),
+        ("init_by_lua", "Usage of Lua initialization is not allowed.\n"),
     ]
 
 logger = logging.getLogger(__name__)

--- a/tests/test_assert_forbidden_statements_in_config.py
+++ b/tests/test_assert_forbidden_statements_in_config.py
@@ -119,4 +119,12 @@ class TestAssertNoForbiddenStatementsInConfig(TestCase):
                 pipes.quote(test), FORBIDDEN_CONFIG_REGEX[1][0]), shell=True
             )
 
+    def test_forbidden_config_init_by_lua_regex_matches_target_directives(self):
+        TEST_CASES = ['init_by_lua', 'init_by_lua_block', 'init_by_lua_file']
+
+        for test in TEST_CASES:
+            with self.assertRaises(CalledProcessError):
+                check_output("[ $(echo {} | grep -P '{}' | wc -l) -lt 1 ]".format(
+                    pipes.quote(test), FORBIDDEN_CONFIG_REGEX[3][0]), shell=True
+                )
 


### PR DESCRIPTION
`inti_by_lua*` directives are executed in the Nginx master process which could lead to privilege escalations.