### PR TITLE
Add *.save to WATCH_IGNORE_FILES

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -31,6 +31,7 @@ WATCH_IGNORE_FILES = (
     # glob patterns
     '.*',
     '*~',
+    '*.save',
     ERROR_FILE
 )
 SYNC_IGNORE_FILES = WATCH_IGNORE_FILES + ('*.flag',)


### PR DESCRIPTION
A little while ago, my colleague got himself into some nginx trouble on a Hypernode.

At one moment, his session was killed by the OOM killer while editing a nginx configuration file. When that happens, nano dumps the buffer to file `filename.save`, as described by [the nano manual](https://www.nano-editor.org/dist/v2.2/nano.1.html#NOTES):

> In some cases nano will try to dump the buffer into an emergency file. This will happen mainly if nano receives a SIGHUP or SIGTERM or runs out of memory. It will write the buffer into a file named nano.save if the buffer didn’t have a name already, or will add a ".save" suffix to the current filename. If an emergency file with that name already exists in the current directory, it will add ".save" plus a number (e.g. ".save.1") to the current filename in order to make it unique. In multibuffer mode, nano will write all the open buffers to their respective emergency files.

Therefore, I think `*.save` files should not be saved and loaded as an nginx configuration. I'm not sure however, if people actually have legit config files called `server.save` (for example). 