### PR TITLE
Ignore error file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ debian/debhelper-*
 debian/nginx-config-reloader.*.debhelper
 debian/nginx-config-reloader.substvars
 debian/nginx-config-reloader/
+
+# ctags
+tags
+ctags


### PR DESCRIPTION
* exclude error file from forbidden configuration items
* always ensure error file is removed before installing new configurations. This is backward incompatible, but only in cases where there was no error).