### PR TITLE
Don't put recursive_watch into the reloader

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -345,7 +345,7 @@ def parse_nginx_config_reloader_arguments():
         '--nocustomconfig', action='store_true', help='Disable copying custom configuration', default=False
     )
     parser.add_argument('--watchdir', '-w', help='Set directory to watch', default=DIR_TO_WATCH)
-    parser.add_argument('--recursivewatch', help='Enable recursive watching of subdirectories', default=False)
+    parser.add_argument('--recursivewatch', action='store_true', help='Enable recursive watching of subdirectories', default=False)
     return parser.parse_args()
 
 
@@ -378,8 +378,7 @@ def main():
             logger=log,
             no_magento_config=args.nomagentoconfig,
             no_custom_config=args.nocustomconfig,
-            dir_to_watch=args.watchdir,
-            recursive_watch=args.recursivewatch
+            dir_to_watch=args.watchdir
         ).apply_new_config()
         return 0
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,8 +47,7 @@ class TestMain(TestCase):
             logger=self.get_logger.return_value,
             no_magento_config=self.parse_nginx_config_reloader_arguments.return_value.nomagentoconfig,
             no_custom_config=self.parse_nginx_config_reloader_arguments.return_value.nocustomconfig,
-            dir_to_watch=self.parse_nginx_config_reloader_arguments.return_value.watchdir,
-            recursive_watch=self.parse_nginx_config_reloader_arguments.return_value.recursivewatch
+            dir_to_watch=self.parse_nginx_config_reloader_arguments.return_value.watchdir
         )
         self.reloader.return_value.apply_new_config()
 

--- a/tests/test_parse_nginx_config_reloader_arguments.py
+++ b/tests/test_parse_nginx_config_reloader_arguments.py
@@ -28,7 +28,7 @@ class TestParseNginxConfigReloaderArguments(TestCase):
                  help='Disable copying custom configuration', default=False),
             call('--watchdir', '-w',
                 help='Set directory to watch', default=nginx_config_reloader.DIR_TO_WATCH),
-            call('--recursivewatch',
+            call('--recursivewatch', action='store_true',
                  help='Enable recursive watching of subdirectories', default=False)
         ]
         self.assertEqual(


### PR DESCRIPTION
Fixes this error:
```
TypeError: my_init() got an unexpected keyword argument 'recursive_watch'
```