### PR TITLE
Process event on dir creation

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -108,6 +108,11 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
         """Triggered by inotify when a file is moved from or to the dir"""
         self.handle_event(event)
 
+    def process_IN_CREATE(self, event):
+        """Triggered by inotify when a dir is created in the watch dir"""
+        if event.dir:
+            self.handle_event(event)
+
     def process_IN_CLOSE_WRITE(self, event):
         """Triggered by inotify when a file is written in the dir"""
         self.handle_event(event)


### PR DESCRIPTION
Process event on_create, but make sure to only trigger on a directory.
If not explicitly checked that it is a directory, multiple events will be triggered when a file is created.

Also added testcases that check callbacks on a subdir of the given watchdir.