### PR TITLE
add dh-python to cow dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Hypertech <hypernode@byte.nl>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), python3, python3-pyinotify, python3-setuptools, dh-systemd
+Build-Depends: debhelper (>= 9), python3, python3-pyinotify, python3-setuptools, dh-systemd, dh-python
 X-Python3-Version: >= 3.5
 
 Package: nginx-config-reloader


### PR DESCRIPTION
fixing this for our debian buster build:
```
dh clean --with python3 --with systemd --buildsystem=pybuild
dh: unable to load addon python3: Can't locate Debian/Debhelper/Sequence/python3.pm in @INC (you may need to install the Debian::Debhelper::Sequence::python3 module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.28.1 /usr/local/share/perl/5.28.1 /usr/lib/x86_64-linux-gnu/perl5/5.28 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.28 /usr/share/perl/5.28 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at (eval 9) line 1.
BEGIN failed--compilation aborted at (eval 9) line 1.
```