### PR TITLE
Fix error caused by  writing bytes (instead of str) to error file

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -181,7 +181,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
                 except subprocess.CalledProcessError:
                     error = "Unable to load config: {}".format(rules[1])
                     self.logger.error(error)
-                    self.write_error_file(error)
+                    self.write_error_file(error.encode())
                     return True
             return False
 
@@ -222,7 +222,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
             self.logger.info("Config check failed")
             if not self.no_custom_config:
                 self.restore_old_custom_config_dir()
-            self.write_error_file(e.output)
+            self.write_error_file(e.output.encode())
             return False
         else:
             self.remove_error_file()

--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -274,7 +274,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
             return None
 
     def write_error_file(self, error):
-        with open(os.path.join(self.dir_to_watch, ERROR_FILE), 'w') as f:
+        with open(os.path.join(self.dir_to_watch, ERROR_FILE), 'wb') as f:
             f.write(error)
 
 

--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -222,7 +222,12 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
             self.logger.info("Config check failed")
             if not self.no_custom_config:
                 self.restore_old_custom_config_dir()
-            self.write_error_file(e.output.encode())
+
+            if sys.version_info < (3, 0):
+                self.write_error_file(e.output)
+            else:
+                self.write_error_file(e.output.encode())
+
             return False
         else:
             self.remove_error_file()

--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -181,7 +181,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
                 except subprocess.CalledProcessError:
                     error = "Unable to load config: {}".format(rules[1])
                     self.logger.error(error)
-                    self.write_error_file(error.encode())
+                    self.write_error_file(error)
                     return True
             return False
 
@@ -223,10 +223,10 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
             if not self.no_custom_config:
                 self.restore_old_custom_config_dir()
 
-            if sys.version_info < (3, 0):
-                self.write_error_file(e.output)
+            if isinstance(e.output, bytes):
+                self.write_error_file(e.output.decode())
             else:
-                self.write_error_file(e.output.encode())
+                self.write_error_file(e.output)
 
             return False
         else:
@@ -279,7 +279,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
             return None
 
     def write_error_file(self, error):
-        with open(os.path.join(self.dir_to_watch, ERROR_FILE), 'wb') as f:
+        with open(os.path.join(self.dir_to_watch, ERROR_FILE), 'w') as f:
             f.write(error)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist=py27,py37,py38
+skipsdist=True
+[testenv]
+deps =
+    nose
+    mock
+    pyinotify
+commands=bash runtests.sh -1


### PR DESCRIPTION
I was receiving an error (in Python 3.8). Setting the file descriptor to `wb` instead of `w` fixed it. I also verify that the error output file contains useful information after writing. 

```
2020-04-29 13:52:03,854 nginx_config_reloader INFO     /home/timon/nginx
2020-04-29 13:52:03,907 nginx_config_reloader INFO     Config check failed
2020-04-29 13:52:03,907 nginx_config_reloader INFO     Listening for changes to /home/timon/nginx
^C[2020-04-29 13:53:36,585 pyinotify ERROR] add_watch: cannot watch /home/timon/nginx WD=-1, Errno=Bad file descriptor (EBADF)
[2020-04-29 13:53:36,585 pyinotify ERROR] add_watch: cannot watch /home/timon WD=-1, Errno=Bad file descriptor (EBADF)
2020-04-29 13:53:36,661 nginx_config_reloader INFO     Config check failed
2020-04-29 13:53:36,662 nginx_config_reloader INFO     Listening for changes to /home/timon/nginx
Traceback (most recent call last):
  File "/usr/local/bin/nginx_config_reloader", line 11, in <module>
    load_entry_point('nginx-config-reloader==20200319.154431', 'console_scripts', 'nginx_config_reloader')()
  File "/usr/local/lib/python3.8/site-packages/nginx_config_reloader/__init__.py", line 373, in main
    wait_loop(
  File "/usr/local/lib/python3.8/site-packages/nginx_config_reloader/__init__.py", line 333, in wait_loop
    notifier.loop()
  File "/usr/lib/python3.8/site-packages/pyinotify.py", line 1376, in loop
    self.process_events()
  File "/usr/lib/python3.8/site-packages/pyinotify.py", line 1276, in process_events
    self._sys_proc_fun.cleanup()  # remove olds MOVED_* events records
AttributeError: 'NoneType' object has no attribute 'cleanup'

```