### PR TITLE
Allow syslog option in access/error_log config

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -52,7 +52,7 @@ FORBIDDEN_CONFIG_REGEX = \
         ("client_body_temp_path", "Usage of configuration parameter client_body_temp_path is not allowed.\n"),
         ("^(?!\s*#)\s*(access|error)_log\s*"
          "(\\042|\\047)?\s*"
-         "(?!(off|on|/+data/+))(?=.*\.\.|/+(?!data)|\w)"
+         "(?!(off|on|/+data/+|syslog:server=(?!unix)))(?=.*\.\.|/+(?!data)|\w)"
          "(\\042|\\047)?\s*",
          "It's not allowed store access_log or error_log outside of /data/.\n"),
         ("^(?!\s*#)\s*(include|load_module)\s*"

--- a/tests/test_assert_forbidden_statements_in_config.py
+++ b/tests/test_assert_forbidden_statements_in_config.py
@@ -95,6 +95,8 @@ class TestAssertNoForbiddenStatementsInConfig(TestCase):
             "access_log  ' /tmp/staging.log';",
             "access_log  ../../../some.log;",
             "access_log  \"../some.log\";",
+            "access_log   syslog:server=unix:/run/systemd/journal/stdout;",
+            "error_log  syslog:server=unix:/run/systemd/journal/stdout;",
         ]
 
         for test in TEST_CASES:
@@ -111,7 +113,9 @@ class TestAssertNoForbiddenStatementsInConfig(TestCase):
             "access_log '/data/var/log/access.log';",
             "     error_log \"/data/var/log/access.log;\"",
             "  access_log   \"//data//var//log//access.log;\"",
-            "#access_log /tmp/log.log;"
+            "#access_log /tmp/log.log;",
+            "access_log syslog:server=log.erikhyperdev.nl:2110 octologs_json;",
+            "access_log syslog:server=[2001:db8::1]:12345,facility=local7,tag=nginx,severity=info combined;"
         ]
 
         for test in TEST_CASES:


### PR DESCRIPTION
Allow all syslog options except unix sockets. So people don't start writing duplicate logs to journalctl or something.

Fixes: https://jira.byte.nl/browse/HNSYS-3924