### PR TITLE
coalesce-events-in-nginx-config-reloader

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -289,6 +289,7 @@ def wait_loop(logger=None, no_magento_config=False, no_custom_config=False, dir_
 
         try:
             logger.info("Listening for changes to {}".format(dir_to_watch))
+            notifier.coalesce_events()
             notifier.loop()
         except pyinotify.NotifierError as err:
             logger.critical(err)


### PR DESCRIPTION
If you trigger a storm of events like:
```
app@j6yt8x-vdloo-magweb-cmbs:~/nginx$ while true; do touch banaan; rm banaan ; done
```

the nginx-config-reloader would queue up all these events and excecute
them one by one:
```
Oct 01 10:48:52 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[11645]: 2021-10-01 10:48:52,151 nginx_config_reloader INFO     Reloading nginx config
Oct 01 10:48:52 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[11645]: 2021-10-01 10:48:52,151 nginx_config_reloader INFO     IN_DELETE detected on banaan
Oct 01 10:48:52 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[11645]: 2021-10-01 10:48:52,309 nginx_config_reloader INFO     Reloading nginx config
Oct 01 10:48:52 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[11645]: 2021-10-01 10:48:52,309 nginx_config_reloader INFO     IN_CLOSE_WRITE detected on banaan
Oct 01 10:48:52 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[11645]: 2021-10-01 10:48:52,459 nginx_config_reloader INFO     Reloading nginx config
Oct 01 10:48:52 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[11645]: 2021-10-01 10:48:52,464 nginx_config_reloader INFO     IN_DELETE detected on banaan
Oct 01 10:48:52 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[11645]: 2021-10-01 10:48:52,596 nginx_config_reloader INFO     Reloading nginx config
Oct 01 10:48:52 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[11645]: 2021-10-01 10:48:52,597 nginx_config_reloader INFO     IN_CLOSE_WRITE detected on banaan
Oct 01 10:48:52 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[11645]: 2021-10-01 10:48:52,746 nginx_config_reloader INFO     Reloading nginx config
etc..
```

by using coalesce_events duplicate events are not processed:
```
app@j6yt8x-vdloo-magweb-cmbs:~/nginx$ while true; do touch banaan; rm banaan ; done
Oct 01 10:52:59 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[27424]: 2021-10-01 10:52:59,992 nginx_config_reloader INFO     IN_CLOSE_WRITE detected on banaan
Oct 01 10:53:00 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[27424]: 2021-10-01 10:53:00,133 nginx_config_reloader ERROR    Installation of custom config failed
Oct 01 10:53:00 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[27424]: 2021-10-01 10:53:00,192 nginx_config_reloader INFO     IN_DELETE detected on banaan
^C
app@j6yt8x-vdloo-magweb-cmbs:~/nginx$ Oct 01 10:53:00 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[27424]: 2021-10-01 10:53:00,365 nginx_config_reloader INFO     Reloading nginx config
Oct 01 10:53:00 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[27424]: 2021-10-01 10:53:00,371 nginx_config_reloader INFO     IN_CLOSE_WRITE detected on banaan
Oct 01 10:53:00 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[27424]: 2021-10-01 10:53:00,526 nginx_config_reloader INFO     Reloading nginx config
Oct 01 10:53:00 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[27424]: 2021-10-01 10:53:00,551 nginx_config_reloader INFO     IN_DELETE detected on banaan
Oct 01 10:53:00 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[27424]: 2021-10-01 10:53:00,695 nginx_config_reloader INFO     Reloading nginx config
Oct 01 10:53:00 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[27424]: 2021-10-01 10:53:00,696 nginx_config_reloader INFO     IN_CLOSE_WRITE detected on banaan
Oct 01 10:53:00 j6yt8x-vdloo-magweb-cmbs.nodes.hypernode.io nginx_config_reloader[27424]: 2021-10-01 10:53:00,850 nginx_config_reloader INFO     Reloading nginx config

app@j6yt8x-vdloo-magweb-cmbs:~/nginx$
```
There would be only as much events as there would be 1 in the queue while 1 is still being processed but no more, which is a lot more efficient.

For more information see: https://github.com/seb-m/pyinotify/blob/master/python3/pyinotify.py#L1157

> Coalescing events. Events are usually processed by batchs, their size
> depend on various factors. Thus, before processing them, events received
> from inotify are aggregated in a fifo queue. If this coalescing
> option is enabled events are filtered based on their unicity, only
> unique events are enqueued, doublons are discarded. An event is unique
> when the combination of its fields (wd, mask, cookie, name) is unique
> among events of a same batch. After a batch of events is processed any
> events is accepted again. By default this option is disabled, you have
> to explictly call this function to turn it on.