### PR TITLE
Skip superfluous config reloads

### DIFF
--- a/nginx_config_reloader/settings.py
+++ b/nginx_config_reloader/settings.py
@@ -4,7 +4,6 @@ CUSTOM_CONFIG_DIR = MAIN_CONFIG_DIR + '/app'
 BACKUP_CONFIG_DIR = MAIN_CONFIG_DIR + '/app_bak'
 UNPRIVILEGED_GID = 1000  # This is the 'app' user on a Hypernode, or generally the first user on any system
 UNPRIVILEGED_UID = 1000  # This is the 'app' user on a Hypernode, or generally the first user on any system
-HANDLE_SLEEP = 5  # Time to wait before reloading. This is handy in case multiple files are touched.
 
 MAGENTO_CONF = MAIN_CONFIG_DIR + '/magento.conf'
 MAGENTO1_CONF = MAIN_CONFIG_DIR + '/magento1.conf'

--- a/nginx_config_reloader/settings.py
+++ b/nginx_config_reloader/settings.py
@@ -4,6 +4,7 @@ CUSTOM_CONFIG_DIR = MAIN_CONFIG_DIR + '/app'
 BACKUP_CONFIG_DIR = MAIN_CONFIG_DIR + '/app_bak'
 UNPRIVILEGED_GID = 1000  # This is the 'app' user on a Hypernode, or generally the first user on any system
 UNPRIVILEGED_UID = 1000  # This is the 'app' user on a Hypernode, or generally the first user on any system
+HANDLE_SLEEP = 5  # Time to wait before reloading. This is handy in case multiple files are touched.
 
 MAGENTO_CONF = MAIN_CONFIG_DIR + '/magento.conf'
 MAGENTO1_CONF = MAIN_CONFIG_DIR + '/magento1.conf'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,7 +49,7 @@ class TestMain(TestCase):
             no_custom_config=self.parse_nginx_config_reloader_arguments.return_value.nocustomconfig,
             dir_to_watch=self.parse_nginx_config_reloader_arguments.return_value.watchdir
         )
-        self.reloader.return_value.apply_new_config()
+        self.reloader.return_value.apply_new_config.assert_called_once_with()
 
     def test_main_does_not_watch_the_config_dir_if_monitor_mode_not_specified(self):
         main()


### PR DESCRIPTION
inspect the queue size inside the eventhandler so we can skip the reload
if we know there are more reloads in the queue

- check if queue length greater than 1, if so skip reload
- wait 5 seconds to reload because mutations usually come in bursts

makes it more efficient to do a big amount of nginx config mutations like:
```
$ hypernode-manage-vhosts staging{1..10}.komkommer.store --type magento2
```