### PR TITLE
take into account None notifier in handle_event

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -79,7 +79,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
         raise ListenTargetTerminated
 
     def handle_event(self, event):
-        if self.notifier.check_events(timeout=100):
+        if self.notifier and self.notifier.check_events(timeout=100):
             self.logger.info("Detected other reloads in queue, skipping this one.")
             return
         if not any(fnmatch.fnmatch(event.name, pat) for pat in WATCH_IGNORE_FILES):

--- a/tests/test_nginx_config_reloader.py
+++ b/tests/test_nginx_config_reloader.py
@@ -329,6 +329,12 @@ class TestConfigReloader(TestCase):
 
         self.kill.assert_called_once_with(42, signal.SIGHUP)
 
+    def test_that_handle_event_applies_config_if_no_notifier(self):
+        tm = self._get_nginx_config_reloader_instance(notifier=None)
+        tm.handle_event(Event('some_file'))
+
+        self.kill.assert_called_once_with(42, signal.SIGHUP)
+
     def test_that_handle_event_does_not_apply_config_if_other_events_in_queue(self):
         notifier = Mock()
         notifier.check_events.return_value = True


### PR DESCRIPTION
> default notifier can be empty (None), so this line could error with attribute exception. :wink'

see https://github.com/ByteInternet/nginx_config_reloader/pull/41