### PR TITLE
Clear inotify eventq before every reload to prevent too many nginx reloads

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -79,11 +79,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
         raise ListenTargetTerminated
 
     def handle_event(self, event):
-        try:
-            while self.notifier._eventq.pop():
-                continue
-        except IndexError:
-            pass
+        self.notifier._eventq.clear()
 
         if not any(fnmatch.fnmatch(event.name, pat) for pat in WATCH_IGNORE_FILES):
             self.logger.info("{} detected on {}.".format(event.maskname, event.name))

--- a/tests/test_nginx_config_reloader.py
+++ b/tests/test_nginx_config_reloader.py
@@ -1,6 +1,7 @@
 import os
 import stat
 import subprocess
+from collections import deque
 from tempfile import mkdtemp, mkstemp, NamedTemporaryFile
 import shutil
 import signal
@@ -37,7 +38,7 @@ class TestConfigReloader(TestCase):
         self.test_config = self.set_up_patch('subprocess.check_output')
         self.kill = self.set_up_patch('os.kill')
         self.error_file = os.path.join(nginx_config_reloader.DIR_TO_WATCH, nginx_config_reloader.ERROR_FILE)
-        self.notifier = Mock(_eventq=list(range(5)))
+        self.notifier = Mock(_eventq=deque(range(5)))
 
     def tearDown(self):
         shutil.rmtree(self.source, ignore_errors=True)
@@ -330,7 +331,7 @@ class TestConfigReloader(TestCase):
 
     def test_that_handle_event_clears_queue(self):
         notifier = Mock()
-        notifier._eventq = list(range(10))
+        notifier._eventq = deque(range(10))
         tm = self._get_nginx_config_reloader_instance(notifier=notifier)
         tm.handle_event(Event('some_file'))
 
@@ -339,7 +340,7 @@ class TestConfigReloader(TestCase):
     def test_that_handle_event_calls_apply_new_config(self):
         apply_new_config_mock = self.set_up_patch('nginx_config_reloader.NginxConfigReloader.apply_new_config')
         notifier = Mock()
-        notifier._eventq = list(range(10))
+        notifier._eventq = deque(range(10))
         tm = self._get_nginx_config_reloader_instance(notifier=notifier)
         tm.handle_event(Event('some_file'))
 


### PR DESCRIPTION
When you do too many things with nginx at the same time it triggers a ton of events, drawing huge amount of resources.
Instead we can clear the queue before reloading because at that point we can assume everything is done and we move everything
anyway.