### PR TITLE
Update test procedure to just tox and pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ the error message from nginx will be placed in `/data/web/nginx/nginx_error_outp
 
 ## Installation
 
-```
+```bash
 python setup.py install
 ```
 
 or
 
-```
+```bash
 pip install -e git+https://github.com/ByteInternet/nginx_config_reloader#egg=nginx_config_reloader
 ```
 
@@ -31,16 +31,16 @@ pip install -e git+https://github.com/ByteInternet/nginx_config_reloader#egg=ngi
 
 ## Running tests
 
-```sh
+```bash
 pip install -r requirements.txt
-./runtests.sh -1
+tox
 ```
 
 ## Building debian packages
 
 To create a package from "master" branch (for production) run the "build.sh" script
 
-```sh
+```bash
 ./build.sh
 ```
 
@@ -49,6 +49,6 @@ This would create a release tag as well.
 If you'd like to create a Debian package of a development branch (without tagging, etc.)
 you can use "_build_local.sh" script
 
-```sh
+```bash
 ./_build_local.sh
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
-mock==1.0.1
-nose==1.3.0
-pyinotify==0.9.4
+pyinotify==0.9.6
+
+mock==5.0.1
+pytest==7.2.1
+pytest-xdist==3.2.0
+tox==4.4.5

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-export PYTHONPATH=.
-
-if [ "$1" == "-1" ]; then
-    nosetests;
-else
-    watch -n 1 -- nosetests;
-fi
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist=py27,py37,py38
+envlist=py37,py38
 skipsdist=True
+
 [testenv]
-deps =
-    nose
-    mock
-    pyinotify
-commands=bash runtests.sh -1
+deps = -rrequirements.txt
+allowlist_externals=bash
+commands=
+    bash -c "pytest tests -n $(nproc)"


### PR DESCRIPTION
This procedure didn't age very well, time for some improvements

- Removed nose
- Updated dependencies
- Updated tox configuration to just run pytest and install from requirements.txt
- Updated instructions in README.md