### PR TITLE
Fix not listening to sub events after subdir is removed and created

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 import argparse
 import fnmatch
+
 import pyinotify
 import subprocess
 import signal
@@ -21,7 +22,6 @@ logger = logging.getLogger(__name__)
 
 
 class NginxConfigReloader(pyinotify.ProcessEvent):
-
     def my_init(
             self, logger=None, no_magento_config=False, no_custom_config=False, dir_to_watch=DIR_TO_WATCH,
             magento2_flag=None, notifier=None, use_systemd=False
@@ -48,6 +48,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
         self.logger.info(self.dir_to_watch)
         self.notifier = notifier
         self.use_systemd = use_systemd
+        self.dirty = False
 
     def process_IN_DELETE(self, event):
         """Triggered by inotify on removal of file or removal of dir
@@ -71,20 +72,14 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
         """Triggered by inotify when a file is written in the dir"""
         self.handle_event(event)
 
-    def process_IN_IGNORED(self, event):
-        """Triggered by inotify when it stops watching"""
-        raise ListenTargetTerminated
-
     def process_IN_MOVE_SELF(self, event):
         """Triggered by inotify when watched dir is moved"""
         raise ListenTargetTerminated
 
     def handle_event(self, event):
-        self.notifier._eventq.clear()
-
         if not any(fnmatch.fnmatch(event.name, pat) for pat in WATCH_IGNORE_FILES):
             self.logger.info("{} detected on {}.".format(event.maskname, event.name))
-            self.apply_new_config()
+            self.dirty = True
 
     def install_magento_config(self):
         # Check if configs are present
@@ -94,7 +89,7 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
         # Create new temporary filename for new config
         MAGENTO_CONF_NEW = MAGENTO_CONF + '_new'
 
-        # Remove tmp link it it exists (leftover?)
+        # Remove tmp link if it exists (leftover?)
         try:
             os.unlink(MAGENTO_CONF_NEW)
         except OSError:
@@ -248,6 +243,12 @@ class ListenTargetTerminated(BaseException):
     pass
 
 
+def after_loop(nginx_config_reloader: NginxConfigReloader) -> None:
+    if nginx_config_reloader.dirty:
+        nginx_config_reloader.apply_new_config()
+        nginx_config_reloader.dirty = False
+
+
 def wait_loop(logger=None, no_magento_config=False, no_custom_config=False, dir_to_watch=DIR_TO_WATCH,
               recursive_watch=False, use_systemd=False):
     """Main event loop
@@ -299,7 +300,7 @@ def wait_loop(logger=None, no_magento_config=False, no_custom_config=False, dir_
         try:
             logger.info("Listening for changes to {}".format(dir_to_watch))
             notifier.coalesce_events()
-            notifier.loop()
+            notifier.loop(callback=lambda _: after_loop(nginx_config_changed_handler))
         except pyinotify.NotifierError as err:
             logger.critical(err)
         except ListenTargetTerminated:

--- a/tests/test_after_loop.py
+++ b/tests/test_after_loop.py
@@ -1,0 +1,54 @@
+from collections import deque
+from tempfile import mkdtemp
+from unittest.mock import Mock
+
+import nginx_config_reloader
+from tests.testcase import TestCase
+
+
+class TestAfterLoop(TestCase):
+    def setUp(self) -> None:
+        self.source = mkdtemp()
+        self.notifier = Mock(_eventq=deque(range(5)))
+
+    def test_it_returns_nothing(self):
+        tm = self._get_nginx_config_reloader_instance()
+
+        result = nginx_config_reloader.after_loop(tm)
+
+        self.assertIsNone(result)
+
+    def test_it_applies_config_if_tree_dirty(self):
+        tm = self._get_nginx_config_reloader_instance()
+        tm.apply_new_config = Mock()
+        tm.dirty = True
+
+        nginx_config_reloader.after_loop(tm)
+
+        tm.apply_new_config.assert_called_once_with()
+        self.assertFalse(tm.dirty)
+
+    def test_it_does_not_apply_config_if_tree_not_dirty(self):
+        tm = self._get_nginx_config_reloader_instance()
+        tm.apply_new_config = Mock()
+        tm.dirty = False
+
+        nginx_config_reloader.after_loop(tm)
+
+        tm.apply_new_config.assert_not_called()
+        self.assertFalse(tm.dirty)
+
+    def _get_nginx_config_reloader_instance(
+        self,
+        no_magento_config=False,
+        no_custom_config=False,
+        magento2_flag=None,
+        notifier=None,
+    ):
+        return nginx_config_reloader.NginxConfigReloader(
+            no_magento_config=no_magento_config,
+            no_custom_config=no_custom_config,
+            dir_to_watch=self.source,
+            magento2_flag=magento2_flag,
+            notifier=notifier or self.notifier,
+        )

--- a/tests/test_inotify_callbacks.py
+++ b/tests/test_inotify_callbacks.py
@@ -86,11 +86,10 @@ class TestInotifyCallbacks(unittest.TestCase):
 
         shutil.rmtree(destdir)
 
-    def test_that_listen_target_terminated_is_raised_if_dir_is_removed(self):
+    def test_that_listen_target_terminated_is_not_raised_if_dir_is_removed(self):
         shutil.rmtree(self.dir)
 
-        with self.assertRaises(nginx_config_reloader.ListenTargetTerminated):
-            self._process_events()
+        self._process_events()
 
 
 class TestInotifyRecursiveCallbacks(TestInotifyCallbacks):


### PR DESCRIPTION
This is solved by:

1. Not raising `ListenTargetTerminated` when receiving `IN_IGNORED` (which is an event sent after a watched directory is removed
2. Not clearing the event queue on event
3. Not acting on each event, instead mark the reloader as `dirty`
4. After event loop, apply config and reload if reloader is `dirty`