### PR TITLE
Fix directory permissions process always failing

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -200,11 +200,10 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
 
     def fix_custom_config_dir_permissions(self):
         try:
-            subprocess.check_output(
-                ['find', self.dir_to_watch, '-type', 'd', '-exec', 'chmod', '0755', '{}', ';'],
-                preexec_fn=as_unprivileged_user,
-                stderr=subprocess.STDOUT
-            )
+            os.chmod(self.dir_to_watch, 0o755)
+            for root, dirs, _ in os.walk(self.dir_to_watch):
+                for name in dirs:
+                    os.chmod(os.path.join(root, name), 0o755)
         except subprocess.CalledProcessError:
             self.logger.info("Failed fixing permissions on watched directory")
 

--- a/tests/test_fix_custom_config_dir_permissions.py
+++ b/tests/test_fix_custom_config_dir_permissions.py
@@ -1,30 +1,28 @@
-import subprocess
+import os
+import tempfile
+from unittest.mock import call
 
-from nginx_config_reloader import NginxConfigReloader, as_unprivileged_user
+from nginx_config_reloader import NginxConfigReloader
 from tests.testcase import TestCase
 
 
 class TestFixCustomConfigDirPermissions(TestCase):
     def setUp(self):
-        self.check_output = self.set_up_patch(
-            'nginx_config_reloader.subprocess.check_output'
-        )
+        self.chmod = self.set_up_patch('os.chmod')
+        self.temp_dir = tempfile.mkdtemp()
         self.tm = NginxConfigReloader(
             no_magento_config=False,
             no_custom_config=False,
-            dir_to_watch='/data/web/nginx',
+            dir_to_watch=self.temp_dir,
             magento2_flag=None
         )
 
     def test_fix_custom_config_dir_permissions_chmods_all_dirs_to_755(self):
+        os.mkdir(self.temp_dir + "/some_dir")
+
         self.tm.fix_custom_config_dir_permissions()
 
-        self.check_output.assert_called_once_with(
-            ['find', self.tm.dir_to_watch, '-type', 'd', '-exec', 'chmod', '0755', '{}', ';'],
-            preexec_fn=as_unprivileged_user,
-            stderr=subprocess.STDOUT
-        )
-
-    def test_fix_custom_config_dir_permissions_does_not_raise_if_find_fails(self):
-        self.check_output.side_effect = subprocess.CalledProcessError('', '', '')
-        self.tm.fix_custom_config_dir_permissions()
+        self.chmod.assert_has_calls([
+            call(self.temp_dir, 0o755),
+            call(self.temp_dir + "/some_dir", 0o755),
+        ])


### PR DESCRIPTION
I tried to make the `find ... -exec ...` command work in Python, but after some time I thought it would be more pythonic to use `os.walk` and `os.chmod` anyway.