### PR TITLE
Ignore symlinks when setting permissions

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -200,13 +200,19 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
 
     def fix_custom_config_dir_permissions(self):
         try:
-            os.chmod(self.dir_to_watch, 0o755)
+            subprocess.check_output(
+                ["chmod", "755", self.dir_to_watch],
+                preexec_fn=as_unprivileged_user,
+            )
             for root, dirs, _ in os.walk(self.dir_to_watch):
                 for name in dirs:
                     path = os.path.join(root, name)
                     if os.path.islink(path):
                         continue
-                    os.chmod(path, 0o755)
+                    subprocess.check_output(
+                        ["chmod", "755", path],
+                        preexec_fn=as_unprivileged_user,
+                    )
         except subprocess.CalledProcessError:
             self.logger.info("Failed fixing permissions on watched directory")
 

--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -203,7 +203,10 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
             os.chmod(self.dir_to_watch, 0o755)
             for root, dirs, _ in os.walk(self.dir_to_watch):
                 for name in dirs:
-                    os.chmod(os.path.join(root, name), 0o755)
+                    path = os.path.join(root, name)
+                    if os.path.islink(path):
+                        continue
+                    os.chmod(path, 0o755)
         except subprocess.CalledProcessError:
             self.logger.info("Failed fixing permissions on watched directory")
 

--- a/tests/test_fix_custom_config_dir_permissions.py
+++ b/tests/test_fix_custom_config_dir_permissions.py
@@ -26,3 +26,11 @@ class TestFixCustomConfigDirPermissions(TestCase):
             call(self.temp_dir, 0o755),
             call(self.temp_dir + "/some_dir", 0o755),
         ])
+
+    def test_fix_custom_config_dir_permissions_ignores_symlinks(self):
+        other_temp_dir = tempfile.mkdtemp()
+        os.symlink(other_temp_dir, self.temp_dir + "/some_pointing_dir")
+
+        self.tm.fix_custom_config_dir_permissions()
+
+        self.chmod.assert_called_once_with(self.temp_dir, 0o755)


### PR DESCRIPTION
If the target directory is within `dir_to_watch`, that directory will have its permission set anyway, however, we do not want to set permissions for target directories outside `dir_to_watch` .