### PR TITLE
dbus: Fix reload command

### DIFF
--- a/nginx_config_reloader/dbus/server.py
+++ b/nginx_config_reloader/dbus/server.py
@@ -18,4 +18,4 @@ class NginxConfigReloaderInterface(InterfaceTemplate):
     def Reload(self):
         """Mark the last reload at current time."""
         # send_signal=False because we don't want to emit the signal
-        self.implementation.apply_new_config(send_signal=False)
+        self.implementation.reload(send_signal=False)


### PR DESCRIPTION
It was supposed to call the reload method instead of apply_new_config directly.