### PR TITLE
debian: Remove dh-systemd build dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,9 @@
 Source: nginx-config-reloader
-Maintainer: Hypertech <hypernode@byte.nl>
+Maintainer: Hypernode Tech Team <tech.team@hypernode.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), python3, python3-pyinotify, python3-setuptools, dh-systemd, dh-python
+Build-Depends: debhelper (>= 9), python3, python3-pyinotify, python3-setuptools, dh-python
 X-Python3-Version: >= 3.5
 
 Package: nginx-config-reloader


### PR DESCRIPTION
This build dependency is not necessary in debian buster and doesn't even exist in debian bookworm