### PR TITLE
reloader: Do not apply config if target dir is unmounted

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -36,6 +36,7 @@ from nginx_config_reloader.settings import (
     UNPRIVILEGED_UID,
     WATCH_IGNORE_FILES,
 )
+from nginx_config_reloader.utils import directory_is_unmounted
 
 logger = logging.getLogger(__name__)
 dbus_loop: Optional[EventLoop] = None
@@ -298,6 +299,12 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
         return self._on_config_reload
 
     def reload(self, send_signal=True):
+        if directory_is_unmounted(self.dir_to_watch):
+            self.logger.warning(
+                f"Directory {self.dir_to_watch} is unmounted, not reloading!"
+            )
+            return
+
         self.apply_new_config()
         if send_signal:
             self._on_config_reload.emit()

--- a/nginx_config_reloader/utils.py
+++ b/nginx_config_reloader/utils.py
@@ -1,0 +1,14 @@
+import json
+import subprocess
+
+
+def directory_is_unmounted(path):
+    output = subprocess.check_output(
+        ["systemctl", "list-units", "-t", "mount", "--all", "-o", "json"],
+        encoding="utf-8",
+    )
+    units = json.loads(output)
+    for unit in units:
+        if unit["description"] == path:
+            return unit["active"] != "active" or unit["sub"] != "mounted"
+    return False

--- a/tests/test_directory_is_unmounted.py
+++ b/tests/test_directory_is_unmounted.py
@@ -1,0 +1,99 @@
+import json
+
+from nginx_config_reloader import directory_is_unmounted
+from tests.testcase import TestCase
+
+
+class TestDirectoryIsUnmounted(TestCase):
+    def setUp(self):
+        self.check_output = self.set_up_patch(
+            "nginx_config_reloader.utils.subprocess.check_output",
+            return_value=json.dumps(
+                [
+                    {
+                        "unit": "-.mount",
+                        "load": "loaded",
+                        "active": "active",
+                        "sub": "mounted",
+                        "description": "Root Mount",
+                    },
+                    {
+                        "unit": "data-web-nginx.mount",
+                        "load": "loaded",
+                        "active": "active",
+                        "sub": "mounted",
+                        "description": "/data/web/nginx",
+                    },
+                ]
+            ),
+        )
+
+    def test_it_calls_systemctl_list_units(self):
+        directory_is_unmounted("/data/web/nginx")
+
+        self.check_output.assert_called_once_with(
+            ["systemctl", "list-units", "-t", "mount", "--all", "-o", "json"],
+            encoding="utf-8",
+        )
+
+    def test_it_returns_false_if_no_mount_found(self):
+        self.check_output.return_value = json.dumps(
+            [
+                {
+                    "unit": "-.mount",
+                    "load": "loaded",
+                    "active": "active",
+                    "sub": "mounted",
+                    "description": "Root Mount",
+                },
+            ]
+        )
+
+        self.assertFalse(directory_is_unmounted("/data/web/nginx"))
+
+    def test_it_returns_false_if_mount_exists_active_mounted(self):
+        self.assertFalse(directory_is_unmounted("/data/web/nginx"))
+
+    def test_it_returns_true_if_mount_exists_not_active(self):
+        self.check_output.return_value = json.dumps(
+            [
+                {
+                    "unit": "-.mount",
+                    "load": "loaded",
+                    "active": "active",
+                    "sub": "mounted",
+                    "description": "Root Mount",
+                },
+                {
+                    "unit": "data-web-nginx.mount",
+                    "load": "loaded",
+                    "active": "inactive",
+                    "sub": "dead",
+                    "description": "/data/web/nginx",
+                },
+            ]
+        )
+
+        self.assertTrue(directory_is_unmounted("/data/web/nginx"))
+
+    def test_it_returns_true_if_mount_exists_active_not_mounted(self):
+        self.check_output.return_value = json.dumps(
+            [
+                {
+                    "unit": "-.mount",
+                    "load": "loaded",
+                    "active": "active",
+                    "sub": "mounted",
+                    "description": "Root Mount",
+                },
+                {
+                    "unit": "data-web-nginx.mount",
+                    "load": "loaded",
+                    "active": "active",
+                    "sub": "dead",
+                    "description": "/data/web/nginx",
+                },
+            ]
+        )
+
+        self.assertTrue(directory_is_unmounted("/data/web/nginx"))


### PR DESCRIPTION
If the target dir is unmounted but is a very specific mount, the config should not be applied, because either the target directory contains incorrect files or it is empty.