### PR TITLE
Add permission error when user cannot write to /etc/nginx folder

### DIFF
--- a/nginx_config_reloader/__init__.py
+++ b/nginx_config_reloader/__init__.py
@@ -36,7 +36,7 @@ from nginx_config_reloader.settings import (
     UNPRIVILEGED_UID,
     WATCH_IGNORE_FILES,
 )
-from nginx_config_reloader.utils import directory_is_unmounted
+from nginx_config_reloader.utils import directory_is_unmounted, can_write_to_main_config_dir
 
 logger = logging.getLogger(__name__)
 dbus_loop: Optional[EventLoop] = None
@@ -195,6 +195,10 @@ class NginxConfigReloader(pyinotify.ProcessEvent):
     def _apply(self):
         logger.debug("Applying new config")
         if self.check_no_forbidden_config_directives_are_present():
+            return False
+        
+        if not can_write_to_main_config_dir():
+            self.logger.error("No write permissions to main nginx config directory, please check your permissions.")
             return False
 
         if not self.no_magento_config:

--- a/nginx_config_reloader/utils.py
+++ b/nginx_config_reloader/utils.py
@@ -1,6 +1,8 @@
 import json
 import subprocess
+import os
 
+from nginx_config_reloader.settings import MAIN_CONFIG_DIR
 
 def directory_is_unmounted(path):
     output = subprocess.check_output(
@@ -12,3 +14,6 @@ def directory_is_unmounted(path):
         if unit["description"] == path:
             return unit["active"] != "active" or unit["sub"] != "mounted"
     return False
+
+def can_write_to_main_config_dir():
+    return os.access(MAIN_CONFIG_DIR, os.W_OK)


### PR DESCRIPTION
Currently users get a very vague message when they run the nginx_config_reloader on an user that isn't able to write to /etc/nginx, this PR should solve this and add the check.

Before:
```
2024-12-30 06:25:19,553 nginx_config_reloader INFO     /data/web/nginx
2024-12-30 06:25:19,553 nginx_config_reloader DEBUG    Applying new config
2024-12-30 06:25:19,647 nginx_config_reloader ERROR    Installation of magento config failed
```

After:
```
2024-12-30 06:22:14,216 nginx_config_reloader INFO     /data/web/nginx
2024-12-30 06:22:14,216 nginx_config_reloader DEBUG    Applying new config
2024-12-30 06:22:14,229 nginx_config_reloader ERROR    No write permissions to main nginx config directory, please check your permissions.
```